### PR TITLE
disable pull file log and enhence property rule action log

### DIFF
--- a/kea/adapter/adb.py
+++ b/kea/adapter/adb.py
@@ -47,7 +47,7 @@ class ADB(Adapter):
 
         self.cmd_prefix = ['adb', "-s", device.serial]
 
-    def run_cmd(self, extra_args):
+    def run_cmd(self, extra_args, disable_log=False):
         """
         run an adb command and return the output
         :return: output of adb command
@@ -67,7 +67,15 @@ class ADB(Adapter):
 
             self.logger.debug('command:')
             self.logger.debug(args)
-            r = subprocess.check_output(args).strip()
+            if not disable_log:
+                r = subprocess.check_output(args).strip()
+            else:
+                # redirect the output to stderr when disable ouput
+                # which will avoid logging in the terminal
+                r = subprocess.check_output(
+                    args,
+                    stderr=subprocess.STDOUT
+                )
             if not isinstance(r, str):
                 r = r.decode()
             self.logger.debug('return:')

--- a/kea/device.py
+++ b/kea/device.py
@@ -843,7 +843,7 @@ class Device(object):
         self.adb.run_cmd(["push", local_file, remote_dir])
 
     def pull_file(self, remote_file, local_file):
-        self.adb.run_cmd(["pull", remote_file, local_file])
+        self.adb.run_cmd(["pull", remote_file, local_file], disable_log=True)
 
     def mkdir(self,path):
         self.adb.run_cmd(["shell","mkdir",path])

--- a/kea/dsl.py
+++ b/kea/dsl.py
@@ -35,8 +35,6 @@ class Mobile(Driver):
     def press(self, key: Union[int, str], meta=None):
         self.droidbot.device.save_screenshot_for_report(event_name="press", event = key)
         super().press(key, meta)
-
-
 class Ui(UiObject):
     session:"Mobile"
 
@@ -46,14 +44,17 @@ class Ui(UiObject):
 
     def click(self, offset=None):
         self.droidbot.device.save_screenshot_for_report(event_name="click")
+        print(f"Property Action: click({str(self.selector)})")
         super().click(offset)
 
     def long_click(self, duration: float = 0.5):
         self.droidbot.device.save_screenshot_for_report(event_name="long_click")
+        print(f"Property Action: long_click({str(self.selector)})")
         super().long_click(duration)
     
     def set_text(self, text):
         self.droidbot.device.save_screenshot_for_report(event_name="set_text " + text)
+        print(f"Property Action: set_text({str(self.selector)})")
         super().set_text(text)
         
     def child(self, **kwargs):

--- a/kea/start.py
+++ b/kea/start.py
@@ -119,9 +119,9 @@ def main():
                        number_of_events_that_restart_app=options.number_of_events_that_restart_app,  # tingsu: do we need a better name?
                        debug_mode=options.debug_mode,
                        keep_app=options.keep_app,
-                       is_harmonyos=options.is_harmonyos
+                       is_harmonyos=options.is_harmonyos,
                        grant_perm=options.grant_perm,
-                       is_emulator=options.is_emulator,
+                       is_emulator=options.is_emulator
                        )
     if options.files is not None:
         test_classes = import_and_instantiate_classes(options.files, settings)


### PR DESCRIPTION
disable the pull file log of the output, add property rule action log

disable log like
```
/sdcard/screen_2024-11-21_124332.png: 1 fil...0 skipped. 8.6 MB/s (66259 bytes in 0.007s)
```

add log like
```
Property Action: click(Selector [resourceId='it.feio.android.omninotes.alpha:id/next'])
```